### PR TITLE
Proxy Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 
 ADD . ./
 
-RUN go build -mod=vendor
+RUN go build
 
 # final image
 FROM alpine:3.9

--- a/authenticator.go
+++ b/authenticator.go
@@ -11,6 +11,12 @@ import (
 	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
 )
 
+const (
+	BasicAuthScheme = "basicauth"
+	SigningScheme   = "ecdsasignatures"
+	NoAuth          = "none"
+)
+
 var (
 	ErrMissingProxyIDHeader        = errors.New("missing Proxy-ID request header")
 	ErrFailedToReadRequestBody     = errors.New("failed to read request body")

--- a/authenticator.go
+++ b/authenticator.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	BASIC_AUTH_SCHEME      = "basicauth"
-	ECDSA_SIGNATURE_SCHEME = "ecdsasignatures"
-	NO_AUTH                = "none"
+	BasicAuthScheme      = "BASIC_AUTH_SCHEME"
+	EcdsaSignatureScheme = "ECDSA_SIGNATURE_SCHEME"
+	NoAuth               = "NO_AUTH_SCHEME"
 )
 
 var (

--- a/authenticator.go
+++ b/authenticator.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	BasicAuthScheme = "basicauth"
-	SigningScheme   = "ecdsasignatures"
-	NoAuth          = "none"
+	BASIC_AUTH_SCHEME      = "basicauth"
+	ECDSA_SIGNATURE_SCHEME = "ecdsasignatures"
+	NO_AUTH                = "none"
 )
 
 var (

--- a/authenticator_test.go
+++ b/authenticator_test.go
@@ -1,11 +1,13 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestAuthenticatorSetup(t *testing.T) {
 	allowedIDs := []string{"036a775c4db73fd351191d0a0e19862ecbb70cbe2626097adfb70ffd4f9ea081bf"}
 	_, err := NewP2PAuthenticator(allowedIDs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }

--- a/basic_authenticator.go
+++ b/basic_authenticator.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	ErrInvalidUserOrPassword = errors.New("incorrect username or password")
+	ErrFailedHttpBasicAuth   = errors.New("failed http basic auth, missing or malformed Authorization headers?")
 )
 
 // BasicAuthenticator uses HTTP Basic Auth to check whether the incoming request
@@ -22,7 +23,7 @@ func (a *BasicAuthenticator) AuthenticateRequest(r *http.Request) error {
 	user, pass, ok := r.BasicAuth()
 
 	if !ok {
-		return errors.New("failed http basic auth, missing or malformed Authorization headers?")
+		return ErrFailedHttpBasicAuth
 	}
 
 	password, userPresent := a.allowedUsers[user]

--- a/basic_authenticator.go
+++ b/basic_authenticator.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var (
+	ErrInvalidUserOrPassword = errors.New("incorrect username or password")
+)
+
+// BasicAuthenticator uses HTTP Basic Auth to check whether the incoming request
+// is allowed access.
+type BasicAuthenticator struct {
+	// mapping of user to password
+	allowedUsers map[string]string
+}
+
+func (a *BasicAuthenticator) AuthenticateRequest(r *http.Request) error {
+	user, pass, ok := r.BasicAuth()
+
+	if !ok {
+		return errors.New("failed http basic auth, missing or malformed Authorization headers?")
+	}
+
+	password, userPresent := a.allowedUsers[user]
+
+	if !userPresent || password != pass {
+		return ErrInvalidUserOrPassword
+	}
+
+	return nil
+}
+
+func NewBasicAuthenticator(allowedUsers map[string]string) (*BasicAuthenticator, error) {
+	if len(allowedUsers) == 0 {
+		return nil, errors.New("provided an empty allowedUsers map")
+	}
+	return &BasicAuthenticator{
+		allowedUsers: allowedUsers,
+	}, nil
+}
+
+// parseAllowedUsesrString is used to convert a user1:password1,user2:password2
+// string into a mapping of users to passwords
+func parseAllowedUsersString(userString string) (map[string]string, error) {
+	if userString == "" {
+		return map[string]string{}, fmt.Errorf("empty userString provided")
+	}
+
+	allowedUsers := map[string]string{}
+	pairs := strings.Split(userString, ",")
+	for _, pair := range pairs {
+		userPassword := strings.Split(pair, ":")
+		if len(userPassword) != 2 {
+			return map[string]string{}, fmt.Errorf("could not parse the following user pair: %s", pair)
+		}
+
+		user, password := strings.TrimSpace(userPassword[0]), strings.TrimSpace(userPassword[1])
+		allowedUsers[user] = password
+	}
+	return allowedUsers, nil
+}
+
+func NewBasicAuthenticatorFromConfigString(allowedUserString string) (*BasicAuthenticator, error) {
+	allowedUsers, err := parseAllowedUsersString(allowedUserString)
+	if err != nil {
+		return nil, err
+	}
+	return NewBasicAuthenticator(allowedUsers)
+}

--- a/basic_authenticator.go
+++ b/basic_authenticator.go
@@ -44,7 +44,7 @@ func NewBasicAuthenticator(userToPassword map[string]string) (*BasicAuthenticato
 	}, nil
 }
 
-// parseAllowedUsesrString is used to convert a user1:password1,user2:password2
+// parseAllowedUsersString is used to convert a user1:password1,user2:password2
 // string into a mapping of users to passwords
 func parseAllowedUsersString(userString string) (map[string]string, error) {
 	if userString == "" {

--- a/basic_authenticator_test.go
+++ b/basic_authenticator_test.go
@@ -1,26 +1,26 @@
 package main
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewBasicAuthenticator(t *testing.T) {
 	_, err := NewBasicAuthenticatorFromConfigString("user:password,becky:hello")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
-func Test_parseAllowedUsersString(t *testing.T) {
+func TestParseAllowedUsersString(t *testing.T) {
 	type args struct {
 		userString string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    map[string]string
-		wantErr bool
+		name      string
+		args      args
+		expected  map[string]string
+		expectErr bool
 	}{
 		{"simple valid test", args{"user:password"}, map[string]string{"user": "password"}, false},
 		{
@@ -29,19 +29,19 @@ func Test_parseAllowedUsersString(t *testing.T) {
 			map[string]string{"user": "password", "user2": "password2"},
 			false,
 		},
-		{"should throw error test", args{"user/password"}, map[string]string{}, true},
-		{"empty string test", args{""}, map[string]string{}, true},
+		{"should throw error test", args{"user/password"}, nil, true},
+		{"empty string test", args{""}, nil, true},
+		{"string contains only commas", args{"user1,user2,user3"}, nil, true},
+		{"string contains only colons", args{"user1:user2:user3"}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := parseAllowedUsersString(tt.args.userString)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseAllowedUsersString() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("parseAllowedUsersString() error = %v, wantErr %v", err, tt.expectErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseAllowedUsersString() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }

--- a/basic_authenticator_test.go
+++ b/basic_authenticator_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewBasicAuthenticator(t *testing.T) {
+	_, err := NewBasicAuthenticatorFromConfigString("user:password,becky:hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_parseAllowedUsersString(t *testing.T) {
+	type args struct {
+		userString string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{"simple valid test", args{"user:password"}, map[string]string{"user": "password"}, false},
+		{
+			"more than one valid test",
+			args{"user:password,user2:password2"},
+			map[string]string{"user": "password", "user2": "password2"},
+			false,
+		},
+		{"should throw error test", args{"user/password"}, map[string]string{}, true},
+		{"empty string test", args{""}, map[string]string{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAllowedUsersString(tt.args.userString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAllowedUsersString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAllowedUsersString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require (
 	github.com/caarlos0/env/v6 v6.0.0
 	github.com/libp2p/go-libp2p v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-crypto v0.1.0
+	github.com/magiconair/properties v1.8.1
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/libp2p/go-ws-transport v0.1.0/go.mod h1:rjw1MG1LU9YDC6gzmwObkPd/Sqwhw
 github.com/libp2p/go-yamux v1.2.2/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.2.3 h1:xX8A36vpXb59frIzWFdEgptLMsOANMFq2K7fPRlunYI=
 github.com/libp2p/go-yamux v1.2.3/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
+github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -232,10 +234,13 @@ github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
@@ -304,4 +309,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/integration_test.go
+++ b/integration_test.go
@@ -116,6 +116,7 @@ func TestBasicSingleProxySetup(t *testing.T) {
 
 	require.Equalf(t, headerValue, TestHeaderValue, "the expected value for %s header is %s instead got %s", TestHeaderKey, TestHeaderValue, headerValue)
 
+	// TODO(oskar) - gracefully stop proxy by the end of the test
 	es.Stop(ctx)
 }
 
@@ -157,5 +158,6 @@ func TestAllowedRegexpProxy(t *testing.T) {
 
 	require.Truef(t, bytes.Equal(bodyBytes, []byte(unauthorizedString)), "the body does not the expected payload, received: %s , expected: %s", bodyBytes, payloadBytes)
 
+	// TODO(oskar) - gracefully stop proxy by the end of the test
 	es.Stop(ctx)
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -98,10 +98,10 @@ func TestBasicSingleProxySetup(t *testing.T) {
 	}
 
 	go func() {
-		t.Log(http.ListenAndServe("localhost:3011", proxy))
+		t.Log(http.ListenAndServe("localhost:3012", proxy))
 	}()
 
-	resp, err := tc.SendPOST("http://localhost:3011/", payloadBytes)
+	resp, err := tc.SendPOST("http://localhost:3012/", payloadBytes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+const TestHeaderKey = "X-Test-Header"
+const TestHeaderValue = "test-value"
+
+type testClient struct {
+	httpClient *http.Client
+}
+
+func (c *testClient) send(method, url string, payload []byte) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, bytes.NewBuffer(payload))
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (c *testClient) SendPOST(url string, data []byte) (*http.Response, error) {
+	return c.send("POST", url, data)
+}
+
+func newTestClient() *testClient {
+	c := &http.Client{}
+	return &testClient{
+		httpClient: c,
+	}
+}
+
+type echoServer struct {
+	server *http.Server
+}
+
+func (e *echoServer) Start() error {
+	return e.server.ListenAndServe()
+}
+
+func (e *echoServer) Stop(ctx context.Context) error {
+	return e.server.Shutdown(ctx)
+}
+
+func newEchoServer(listenString string) *echoServer {
+	m := http.NewServeMux()
+	server := &http.Server{
+		Addr:    listenString,
+		Handler: m,
+	}
+	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := ioutil.ReadAll(r.Body)
+
+		fmt.Println("received request with the following body: ", string(bodyBytes))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+
+		w.Header().Add(TestHeaderKey, TestHeaderValue)
+
+		io.Copy(w, bytes.NewBuffer(bodyBytes))
+	})
+
+	return &echoServer{server}
+}
+
+func TestBasicSingleProxySetup(t *testing.T) {
+	tc := newTestClient()
+	es := newEchoServer("localhost:3010")
+
+	ctx := context.TODO()
+
+	payload := fmt.Sprintf("{%q:%q}", "hello", "world")
+	payloadBytes := []byte(payload)
+
+	go es.Start()
+
+	proxyConfig := ProxyConfig{
+		RemoteAddress:   "http://localhost:3010/",
+		InputValidation: false,
+	}
+	proxy, err := NewProxy(&proxyConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		t.Log(http.ListenAndServe("localhost:3011", proxy))
+	}()
+
+	resp, err := tc.SendPOST("http://localhost:3011/", payloadBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read body with err: %s", err)
+	}
+
+	if !bytes.Equal(bodyBytes, payloadBytes) {
+		t.Fatalf("the body does not the expected payload, received: %s , expected: %s", bodyBytes, payloadBytes)
+	}
+
+	headerValue := resp.Header.Get(TestHeaderKey)
+
+	if headerValue != TestHeaderValue {
+		t.Fatalf("the expected value for %s header is %s instead got %s", TestHeaderKey, TestHeaderValue, headerValue)
+	}
+
+	es.Stop(ctx)
+
+}
+
+func TestAllowedRegexpProxy(t *testing.T) {
+	tc := newTestClient()
+	es := newEchoServer("localhost:3010")
+
+	ctx := context.TODO()
+
+	payload := fmt.Sprintf("{%q:%q}", "hello", "world")
+	payloadBytes := []byte(payload)
+
+	go es.Start()
+
+	proxyConfig := ProxyConfig{
+		RemoteAddress:    "http://localhost:3010/",
+		InputValidation:  false,
+		AllowedPathRegex: "/$",
+	}
+	proxy, err := NewProxy(&proxyConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		t.Log(http.ListenAndServe("localhost:3011", proxy))
+	}()
+
+	resp, err := tc.SendPOST("http://localhost:3011/unallowed/path", payloadBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode == 200 {
+		t.Fatal("expected status code to not be 200")
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read body with err: %s", err)
+	}
+
+	unauthorizedString := fmt.Sprintf("{%q:%q}", "message", "unauthorized")
+	if !bytes.Equal(bodyBytes, []byte(unauthorizedString)) {
+		t.Fatalf("the body does not the expected payload, received: %s , expected: %s", bodyBytes, payloadBytes)
+	}
+
+	es.Stop(ctx)
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -125,9 +125,6 @@ func TestAllowedRegexpProxy(t *testing.T) {
 
 	ctx := context.TODO()
 
-	payload := fmt.Sprintf("{%q:%q}", "hello", "world")
-	payloadBytes := []byte(payload)
-
 	go es.Start()
 
 	proxyConfig := ProxyConfig{
@@ -142,6 +139,9 @@ func TestAllowedRegexpProxy(t *testing.T) {
 	go func() {
 		t.Log(http.ListenAndServe("localhost:3011", proxy))
 	}()
+
+	payload := fmt.Sprintf("{%q:%q}", "hello", "world")
+	payloadBytes := []byte(payload)
 
 	resp, err := tc.SendPOST("http://localhost:3011/disallowed/path", payloadBytes)
 

--- a/main.go
+++ b/main.go
@@ -10,23 +10,23 @@ import (
 )
 
 type ProxyConfig struct {
-	// Port on whch the proxy is listening on
+	// Port on which the proxy is listening on
 	Port int `env:"PORT" envDefault:"3000"`
 
 	// Proxy target
 	RemoteAddress string `env:"REMOTE_ADDRESS"`
 
-	// InputValidation enables the proxy to validate / authenticate the
+	// ShouldValidateRequests enables the proxy to validate / authenticate the
 	// incoming proxy requests using
-	InputValidation bool `env:"INPUT_VALIDATION"`
+	ShouldValidateRequests bool `env:"SHOULD_VALIDATE_REQUESTS"`
 
 	// one of: [ "ecdsasignatures", "basicauth", "none" ]
 	AuthenticationScheme string `env:"AUTHENTICATION_SCHEME" envDefault:"basicauth"`
 
 	// if AuthenticationScheme is basicauth then this string is used for
-	// determinig allowed user / password pairs.
+	// determining allowed user / password pairs.
 	// NOTE: the string format is: user1:password1,user2:password2
-	AllowedBasicAuthUserString string `env:"ALLOWED_USERS_STRING" envDefault:""`
+	AllowedBasicAuthUserString string `env:"ALLOWED_USERS_BASIC_AUTH_STRING" envDefault:""`
 
 	// If AuthenticationScheme is ecdsasigning then this string is used for
 	// determining allowed public identities
@@ -34,14 +34,14 @@ type ProxyConfig struct {
 	AllowedIDs string `env:"ALLOWED_IDS"`
 
 	// Should the proxied request be signed by auth-es-proxy
-	OutputSigning bool `env:"OUTPUT_SIGNING"`
+	ShouldSignOutgoing bool `env:"SHOULD_SIGN_OUTGOING"`
 
 	// Private Key is required when output signing is set to true
 	PrivateKeyPath string `env:"PRIVATE_KEY_PATH"`
 
-	// If set to an non-empty string the proxy will check whether the
-	// requested path matches the this REGEX pattern otherwise returns
-	// unaothrized
+	// If set to a non-empty string the proxy will check whether the
+	// requested path matches this REGEX pattern otherwise returns
+	// unauthorized
 	AllowedPathRegex string `env:"ALLOWED_PATH_REGEX" envDefault:""`
 }
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,11 @@ type ProxyConfig struct {
 	OutputSigning bool `env:"OUTPUT_SIGNING"`
 	// Private Key is required when output signing is set to true
 	PrivateKeyPath string `env:"PRIVATE_KEY_PATH"`
+
+	// If set to an non-empty string the proxy will check whether the
+	// requested path matches the this REGEX pattern, otherwise returns
+	// unaothrized
+	AllowedPathRegex string `env:"ALLOWED_PATH_REGEX" envDefault:""`
 }
 
 func main() {
@@ -41,6 +46,7 @@ func main() {
 	}
 
 	listenString := fmt.Sprintf(":%d", cfg.Port)
+	log.Infof("starting proxy on: %s", listenString)
 	if err := http.ListenAndServe(listenString, proxy); err != nil {
 		log.Panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -10,24 +10,37 @@ import (
 )
 
 type ProxyConfig struct {
+	// Port on whch the proxy is listening on
 	Port int `env:"PORT" envDefault:"3000"`
 
 	// Proxy target
 	RemoteAddress string `env:"REMOTE_ADDRESS"`
 
-	// InputValidation enables the proxy to validate the incoming proxy
-	// requests using
+	// InputValidation enables the proxy to validate / authenticate the
+	// incoming proxy requests using
 	InputValidation bool `env:"INPUT_VALIDATION"`
-	// Allowed Public identities passed in as comma separated b64 encoded
-	// pubkeys
+
+	// one of: [ "ecdsasignatures", "basicauth", "none" ]
+	AuthenticationScheme string `env:"AUTHENTICATION_SCHEME" envDefault:"basicauth"`
+
+	// if AuthenticationScheme is basicauth then this string is used for
+	// determinig allowed user / password pairs.
+	// NOTE: the string format is: user1:password1,user2:password2
+	AllowedBasicAuthUserString string `env:"ALLOWED_USERS_STRING" envDefault:""`
+
+	// If AuthenticationScheme is ecdsasigning then this string is used for
+	// determining allowed public identities
+	// NOTE: the string format is a comma separated b64 encoded pubkeys
 	AllowedIDs string `env:"ALLOWED_IDS"`
 
+	// Should the proxied request be signed by auth-es-proxy
 	OutputSigning bool `env:"OUTPUT_SIGNING"`
+
 	// Private Key is required when output signing is set to true
 	PrivateKeyPath string `env:"PRIVATE_KEY_PATH"`
 
 	// If set to an non-empty string the proxy will check whether the
-	// requested path matches the this REGEX pattern, otherwise returns
+	// requested path matches the this REGEX pattern otherwise returns
 	// unaothrized
 	AllowedPathRegex string `env:"ALLOWED_PATH_REGEX" envDefault:""`
 }

--- a/signer_test.go
+++ b/signer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/stretchr/testify/require"
 )
 
 const signerData = `
@@ -25,34 +26,25 @@ func TestSignAndAuth(t *testing.T) {
 
 	err = signer.SignRequest(request)
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	allowedIDs := []string{"036a775c4db73fd351191d0a0e19862ecbb70cbe2626097adfb70ffd4f9ea081bf"}
 	auth, err := NewP2PAuthenticator(allowedIDs)
-	if err != nil {
-		t.Fatal(err)
-	}
+
+	require.NoError(t, err)
 
 	err = auth.AuthenticateRequest(request)
-	if err != nil {
-		t.Fatalf("did not properly authenticate the request with err: %s", err)
-	}
 
+	require.NoError(t, err, "did not properly authenticate the request with err: %s")
 }
 
 func TestLoadPrivateKey(t *testing.T) {
 	expectedSignerPubKey := "036a775c4db73fd351191d0a0e19862ecbb70cbe2626097adfb70ffd4f9ea081bf"
 	signer, err := NewP2PSignerFromKeyPath("./__fixtures__/privkey")
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	if signer.PubKey() != expectedSignerPubKey {
-		t.Fatalf("invalid pubkey, expected %s instead got %s", expectedSignerPubKey, signer.PubKey())
-	}
+	require.NoError(t, err)
 
+	require.Equalf(t, signer.PubKey(), expectedSignerPubKey, "invalid pubkey, expected %s instead got %s", expectedSignerPubKey, signer.PubKey())
 }
 
 func BenchmarkSigningData(b *testing.B) {


### PR DESCRIPTION
About
===

This PR:
* Adds a set of integration tests to check the full flow of requests of client <-> proxy <-> end-server
* Added a REGEX env variables to handle path access control
* Moved the Request Proxying to `httputil`'s `SingleHostReverseProxy`
* Added HTTP Basic Auth as an authentication method